### PR TITLE
Rename the project to Surf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/golang:latest
 
-WORKDIR shawty
+WORKDIR surf
 
 COPY . .
 
@@ -8,4 +8,4 @@ EXPOSE 1234
 
 RUN go mod tidy
 RUN go build
-CMD ["./shawty"]
+CMD ["./surf"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Shawty
+# Surf
 
-**Shawty** is a URL shortener built using [Golang](https://go.dev),
+**Surf** is a URL shortener built using [Golang](https://go.dev),
 [Turso](https://turso.tech) and [HTMX](https://htmx.org). It provides a simple
 web interface for shortening URLs, tracking their usage, and offering
 statistics about shortened URLs.
@@ -33,8 +33,8 @@ also checks if the URL contains a valid
 
 1. **Clone the repository**:
    ```bash
-   git clone https://github.com/wavly/shawty.git
-   cd shawty
+   git clone https://github.com/wavly/surf.git
+   cd surf
    ```
 2. **Set ENV Variables**:
 
@@ -86,4 +86,4 @@ We welcome any contributions to this project! For major changes, please open an 
 
 ## LICENSE
 
-- Shawty is [Licensed](LICENSE) under MIT
+- Surf is [Licensed](LICENSE) under MIT

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ also checks if the URL contains a valid
 Use the `make` command to run/build the web server.
 
 > [!NOTE]
-> Make sure the `ENVIROMENT` variable in `.evn.local` is set to `dev` in order run the server in development mode.
+> Make sure the `ENVIROMENT` variable in `.env.local` is set to `dev` in order run the server in development mode.
 
 #### Requirements
 

--- a/asserts/assert.go
+++ b/asserts/assert.go
@@ -3,7 +3,7 @@ package asserts
 import (
 	"os"
 
-	prettylogger "github.com/wavly/shawty/pretty-logger"
+	prettylogger "github.com/wavly/surf/pretty-logger"
 )
 
 var logger = prettylogger.GetLogger(nil)

--- a/config/config.go
+++ b/config/config.go
@@ -4,9 +4,9 @@ import (
 	"os"
 
 	"github.com/joho/godotenv"
-	"github.com/wavly/shawty/asserts"
-	. "github.com/wavly/shawty/env"
-	prettylogger "github.com/wavly/shawty/pretty-logger"
+	"github.com/wavly/surf/asserts"
+	. "github.com/wavly/surf/env"
+	prettylogger "github.com/wavly/surf/pretty-logger"
 )
 
 var logger = prettylogger.GetLogger(nil)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wavly/shawty
+module github.com/wavly/surf
 
 go 1.23.1
 

--- a/handlers/redirect.go
+++ b/handlers/redirect.go
@@ -6,12 +6,12 @@ import (
 	"time"
 
 	"github.com/patrickmn/go-cache"
-	"github.com/wavly/shawty/asserts"
-	. "github.com/wavly/shawty/cache"
-	"github.com/wavly/shawty/internal/database"
-	prettylogger "github.com/wavly/shawty/pretty-logger"
-	"github.com/wavly/shawty/utils"
-	"github.com/wavly/shawty/validate"
+	"github.com/wavly/surf/asserts"
+	. "github.com/wavly/surf/cache"
+	"github.com/wavly/surf/internal/database"
+	prettylogger "github.com/wavly/surf/pretty-logger"
+	"github.com/wavly/surf/utils"
+	"github.com/wavly/surf/validate"
 )
 
 var Logger = prettylogger.GetLogger(nil)

--- a/handlers/short.go
+++ b/handlers/short.go
@@ -7,17 +7,17 @@ import (
 	"html/template"
 	"net/http"
 
-	"github.com/wavly/shawty/asserts"
-	"github.com/wavly/shawty/internal/database"
-	"github.com/wavly/shawty/utils"
-	"github.com/wavly/shawty/validate"
+	"github.com/wavly/surf/asserts"
+	"github.com/wavly/surf/internal/database"
+	"github.com/wavly/surf/utils"
+	"github.com/wavly/surf/validate"
 )
 
 type ShortLink struct {
 	ShortUrl string
 }
 
-func Shawty(w http.ResponseWriter, r *http.Request) {
+func Short(w http.ResponseWriter, r *http.Request) {
 	inputUrl := r.FormValue("url")
 	Logger.Info("Shorten the URL", "url", inputUrl, "user-agent", r.UserAgent())
 

--- a/handlers/stats.go
+++ b/handlers/stats.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 
 	"github.com/mergestat/timediff"
-	"github.com/wavly/shawty/asserts"
-	"github.com/wavly/shawty/internal/database"
-	"github.com/wavly/shawty/utils"
-	"github.com/wavly/shawty/validate"
+	"github.com/wavly/surf/asserts"
+	"github.com/wavly/surf/internal/database"
+	"github.com/wavly/surf/utils"
+	"github.com/wavly/surf/validate"
 )
 
 type AccessCount struct {

--- a/handlers/unshort.go
+++ b/handlers/unshort.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 
 	"github.com/patrickmn/go-cache"
-	"github.com/wavly/shawty/asserts"
-	. "github.com/wavly/shawty/cache"
-	"github.com/wavly/shawty/internal/database"
-	"github.com/wavly/shawty/utils"
-	"github.com/wavly/shawty/validate"
+	"github.com/wavly/surf/asserts"
+	. "github.com/wavly/surf/cache"
+	"github.com/wavly/surf/internal/database"
+	"github.com/wavly/surf/utils"
+	"github.com/wavly/surf/validate"
 )
 
 func Unshort(w http.ResponseWriter, r *http.Request) {
@@ -37,8 +37,8 @@ func Unshort(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if domain matches
-	if parsedUrl.Host != "shawty.wavly.tech" || parsedUrl.Scheme != "https" {
-		asserts.NoErr(errorTempl.Execute(w, "URL must use 'https://shawty.wavly.tech'"), "Failed to execute template short-link-error.html")
+	if parsedUrl.Host != "surf.wavly.tech" || parsedUrl.Scheme != "https" {
+		asserts.NoErr(errorTempl.Execute(w, "URL must use 'https://surf.wavly.tech'"), "Failed to execute template short-link-error.html")
 		return
 	}
 
@@ -68,7 +68,7 @@ func Unshort(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			if err == sql.ErrNoRows {
 				Logger.Warn("url doesn't exists in the database", "code", code, "user-agent", r.UserAgent(), "error", err)
-				asserts.NoErr(errorTempl.Execute(w, "There is no destination URL for this short URL: "+"wavly.shawty.com/s/"+code), "Failed to execute template short-link-error.html")
+				asserts.NoErr(errorTempl.Execute(w, "There is no destination URL for this short URL: "+"wavly.surf.com/s/"+code), "Failed to execute template short-link-error.html")
 				return
 			}
 

--- a/main.go
+++ b/main.go
@@ -6,14 +6,14 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/wavly/shawty/asserts"
-	"github.com/wavly/shawty/config"
-	"github.com/wavly/shawty/env"
-	"github.com/wavly/shawty/handlers"
-	"github.com/wavly/shawty/internal/database"
-	prettylogger "github.com/wavly/shawty/pretty-logger"
-	"github.com/wavly/shawty/utils"
-	"github.com/wavly/shawty/validate"
+	"github.com/wavly/surf/asserts"
+	"github.com/wavly/surf/config"
+	"github.com/wavly/surf/env"
+	"github.com/wavly/surf/handlers"
+	"github.com/wavly/surf/internal/database"
+	prettylogger "github.com/wavly/surf/pretty-logger"
+	"github.com/wavly/surf/utils"
+	"github.com/wavly/surf/validate"
 )
 
 func main() {
@@ -82,7 +82,7 @@ func main() {
 	})
 
 	// API route for shortening the URL
-	router.HandleFunc("POST /shawty", handlers.Shawty)
+	router.HandleFunc("POST /short", handlers.Short)
 
 	// API route for unshortening the URL
 	router.HandleFunc("POST /unshort", handlers.Unshort)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "shawty",
+  "name": "surf",
   "dependencies": {
     "tailwindcss": "^3.4.14"
   },

--- a/partial-html/short-link.html
+++ b/partial-html/short-link.html
@@ -1,6 +1,6 @@
 <div class="flex flex-col items-center gap-4 text-lg font-mono mb-2 mt-10 text-center">
   <div class="flex items-center gap-2">
-    <a class="underline text-white" href="/s/{{ .ShortUrl }}">shawty/s/{{ .ShortUrl }}</a>
+    <a class="underline text-white" href="/s/{{ .ShortUrl }}">short/s/{{ .ShortUrl }}</a>
     <button onclick="copyToClipboard(this, '/s/{{ .ShortUrl }}')" class="bg-zinc-700 hover:bg-zinc-600 text-white font-bold py-1 px-3 rounded transition duration-300">
       Copy
     </button>

--- a/pretty-logger/log.go
+++ b/pretty-logger/log.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/wavly/shawty/env"
+	"github.com/wavly/surf/env"
 )
 
 const (

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
     <meta name="title" content="Surf - Tool for shortening long URLs" />
     <meta
       name="description"
-      content="Shawty is a tool for shortening long URLs making it easy to share them"
+      content="Surf is a tool for shortening long URLs making it easy to share them"
     />
     <script
       src="https://unpkg.com/htmx.org@2.0.2"

--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="title" content="Shawty - Tool for shortening long URLs" />
+    <meta name="title" content="Surf - Tool for shortening long URLs" />
     <meta
       name="description"
       content="Shawty is a tool for shortening long URLs making it easy to share them"
@@ -13,7 +13,7 @@
       integrity="sha384-Y7hw+L/jvKeWIRRkqWYfPcvVxHzVzn5REgzbawhxAuQGwX1XWe70vji+VSeHOThJ"
       crossorigin="anonymous"
     ></script>
-    <title>Shawty</title>
+    <title>Surf</title>
     <link rel="stylesheet" href="/static/dist.css" />
     <style>
       a {
@@ -24,11 +24,11 @@
   <body class="bg-[#090909] text-[#ada9a9] min-h-screen flex flex-col items-center px-4 sm:px-6 lg:px-8">
     <main class="w-full max-w-4xl mx-auto mt-8">
       <h1 class="text-4xl sm:text-5xl text-center text-white font-bold">
-        Shawty
+        Surf
       </h1>
       <p class="text-center text-lg mb-10">
-        Shawty is a free and
-        <a class="underline" target="_blank" href="https://github.com/wavly/shawty">open-source</a> tool for
+        Surf is a free and
+        <a class="underline" target="_blank" href="https://github.com/wavly/surf">open-source</a> tool for
         shortening long URLs
       </p>
 
@@ -38,7 +38,7 @@
         </h2>
         <form
           class="flex flex-col sm:flex-row justify-center gap-4 sm:gap-0 mb-6 relative"
-          hx-post="/shawty"
+          hx-post="/short"
           hx-target="#return"
         >
         <div class="relative">
@@ -74,7 +74,7 @@
         Simple and fast URL shortener!
       </h2>
       <p class="text-lg mb-6">
-        Shawty allows you to shorten long links from various platforms like
+        Surf allows you to shorten long links from various platforms like
         <a class="underline" target="_blank" href="https://www.instagram.com">Instagram</a>,
         <a class="underline" target="_blank" href="https://facebook.com">Facebook</a>,
         <a class="underline" target="_blank" href="https://youtube.com">YouTube</a>,
@@ -96,7 +96,7 @@
         of hits from your URL with our click counter.
       </p>
       <footer class="border-t border-white w-full py-3">
-        <p class="text-center">&copy; wavly.shawty.com - Tool for shortening long links</p>
+        <p class="text-center">&copy; surf.wavly.tech - Tool for shortening long links</p>
       </footer>
     </main>
   </body>

--- a/static/unshort.html
+++ b/static/unshort.html
@@ -3,17 +3,17 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="title" content="Shawty - Tool for shortening long URLs" />
+    <meta name="title" content="Surf - Tool for shortening long URLs" />
     <meta
       name="description"
-      content="Shawty is a tool for shortening long URLs making it easy to share them"
+      content="Surf is a tool for shortening long URLs making it easy to share them"
     />
     <script
       src="https://unpkg.com/htmx.org@2.0.2"
       integrity="sha384-Y7hw+L/jvKeWIRRkqWYfPcvVxHzVzn5REgzbawhxAuQGwX1XWe70vji+VSeHOThJ"
       crossorigin="anonymous"
     ></script>
-    <title>Shawty</title>
+    <title>Surf</title>
     <link rel="stylesheet" href="/static/dist.css" />
     <style>
       a {
@@ -24,11 +24,11 @@
   <body class="bg-[#090909] text-[#ada9a9] min-h-screen flex flex-col items-center px-4 sm:px-6 lg:px-8">
     <main class="w-full max-w-4xl mx-auto mt-8">
       <h1 class="text-4xl sm:text-5xl text-center text-white font-bold">
-        <a class="no-underline" href="/">Shawty</a>
+        <a class="no-underline" href="/">Surf</a>
       </h1>
       <p class="text-center text-lg mb-10">
-        Shawty is a free and
-        <a class="underline" target="_blank" href="https://github.com/wavly/shawty">open-source</a> tool for
+        Surf is a free and
+        <a class="underline" target="_blank" href="https://github.com/wavly/surf">open-source</a> tool for
         shortening long URLs
       </p>
 

--- a/templs/404.html
+++ b/templs/404.html
@@ -4,12 +4,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="title" content="Shawty - Tool for shortening long URLs">
-  <meta name="description" content="Shawty is a tool for shortening long URLs making it easy to share them">
+  <meta name="title" content="Surf - Tool for shortening long URLs">
+  <meta name="description" content="Surf is a tool for shortening long URLs making it easy to share them">
   <script src="https://unpkg.com/htmx.org@2.0.2"
     integrity="sha384-Y7hw+L/jvKeWIRRkqWYfPcvVxHzVzn5REgzbawhxAuQGwX1XWe70vji+VSeHOThJ"
     crossorigin="anonymous"></script>
-  <title>Shawty</title>
+  <title>Surf</title>
   <link rel="stylesheet" href="/static/dist.css">
   <style>
     a {

--- a/templs/server-error.html
+++ b/templs/server-error.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="title" content="Internal Server Error">
-  <meta name="description" content="Shawty is a tool for shortening long URLs making it easy to share them">
+  <meta name="description" content="Surf is a tool for shortening long URLs making it easy to share them">
   <title>Internal Server Error</title>
   <link rel="stylesheet" href="/static/dist.css">
 </head>

--- a/templs/stat.html
+++ b/templs/stat.html
@@ -3,25 +3,25 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="title" content="Shawty - Tool for shortening long URLs">
-    <meta name="description" content="Shawty is a tool for shortening long URLs making it easy to share them">
-    <title>Shawty - URL Statistics</title>
+    <meta name="title" content="Surf - Tool for shortening long URLs">
+    <meta name="description" content="Surf is a tool for shortening long URLs making it easy to share them">
+    <title>Surf - URL Statistics</title>
     <link rel="stylesheet" href="/static/dist.css">
   </head>
   <body class="bg-[#090909] text-[#ada9a9] min-h-screen flex flex-col items-center px-4 sm:px-6 lg:px-8 py-8 mt-8">
     <h1 class="text-4xl sm:text-5xl text-center text-white font-bold">
-      Shawty
+      Surf
     </h1>
     <p class="text-center text-lg mb-10">
-      Shawty is a free and
-      <a class="underline" target="_blank" href="https://github.com/wavly/shawty">open-source</a> tool for
+      Surf is a free and
+      <a class="underline" target="_blank" href="https://github.com/wavly/surf">open-source</a> tool for
       shortening long URLs
     </p>
 
     <div class="fw-full max-w-4xl flex flex-col gap-3 my-4 mx-auto">
       <h2 class="text-2xl sm:text-3xl font-bold font-mono">Total number of clicks</h2>
       <p class="text-base sm:text-lg">The number of clicks from the shortened URL that redirected the user to the destination page.</p>
-      <a class="underline bg-[#292929] font-mono p-2 w-fit rounded-md text-white break-all" href="/s/{{ .ShortUrl }}">shawty/s/{{ .ShortUrl }}</a>
+      <a class="underline bg-[#292929] font-mono p-2 w-fit rounded-md text-white break-all" href="/s/{{ .ShortUrl }}">short/s/{{ .ShortUrl }}</a>
       <p class="text-base sm:text-lg font-bold flex flex-col sm:flex-row gap-2 sm:gap-3">
         <span>Original URL:</span>
         <a class="underline font-mono break-all" href="{{ .OriginalUrl }}">{{ .OriginalUrl }}</a>

--- a/templs/url-info.html
+++ b/templs/url-info.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="title" content="Shawty - Tool for shortening long URLs" />
+    <meta name="title" content="Surf - Tool for shortening long URLs" />
     <meta
       name="description"
-      content="Shawty is a tool for shortening long URLs making it easy to share them"
+      content="Surf is a tool for shortening long URLs making it easy to share them"
     />
-    <title>Shawty</title>
+    <title>Surf</title>
     <link rel="stylesheet" href="/static/dist.css" />
     <script defer src="/static/url-info.js"></script>
     <style>
@@ -20,11 +20,11 @@
   <body class="bg-[#090909] text-[#ada9a9] min-h-screen flex flex-col items-center px-4 sm:px-6 lg:px-8">
     <main class="w-full max-w-4xl mx-auto mt-8">
       <h1 class="text-4xl sm:text-5xl text-center text-white font-bold">
-        <a class="no-underline" href="/">Shawty</a>
+        <a class="no-underline" href="/">Surf</a>
       </h1>
       <p class="text-center text-lg mb-10">
-        Shawty is a free and
-        <a class="underline" target="_blank" href="https://github.com/wavly/shawty">open-source</a> tool for
+        Surf is a free and
+        <a class="underline" target="_blank" href="https://github.com/wavly/surf">open-source</a> tool for
         shortening long URLs
       </p>
 

--- a/utils/database.go
+++ b/utils/database.go
@@ -4,8 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/wavly/shawty/asserts"
-	"github.com/wavly/shawty/env"
+	"github.com/wavly/surf/asserts"
+	"github.com/wavly/surf/env"
 
 	_ "github.com/tursodatabase/go-libsql"
 )

--- a/utils/live-reload.go
+++ b/utils/live-reload.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/wavly/shawty/asserts"
-	"github.com/wavly/shawty/env"
+	"github.com/wavly/surf/asserts"
+	"github.com/wavly/surf/env"
 )
 
 // Injects a script into the [Template File] to live-reload the page if in `DEV` mode,

--- a/utils/server_error_templ.go
+++ b/utils/server_error_templ.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"net/http"
 
-	"github.com/wavly/shawty/asserts"
+	"github.com/wavly/surf/asserts"
 )
 
 func ServerErrTempl(w http.ResponseWriter, msg string) {

--- a/validate/evict_old_links.go
+++ b/validate/evict_old_links.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/wavly/shawty/internal/database"
-	prettylogger "github.com/wavly/shawty/pretty-logger"
+	"github.com/wavly/surf/internal/database"
+	prettylogger "github.com/wavly/surf/pretty-logger"
 )
 
 // Evict Old links form the database

--- a/validate/evict_old_links_test.go
+++ b/validate/evict_old_links_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	_ "github.com/tursodatabase/go-libsql"
-	"github.com/wavly/shawty/internal/database"
+	"github.com/wavly/surf/internal/database"
 )
 
 // TestEvictOldLinks validates the EvictOldLinks function.

--- a/validate/validate_code.go
+++ b/validate/validate_code.go
@@ -3,7 +3,7 @@ package validate
 import (
 	"fmt"
 
-	"github.com/wavly/shawty/utils"
+	"github.com/wavly/surf/utils"
 )
 
 type TooLong struct {

--- a/validate/validate_url.go
+++ b/validate/validate_url.go
@@ -49,19 +49,13 @@ func ValidateUrl(link string) (string, error) {
 		return link, &UrlTooLong{}
 	}
 
+	if !strings.HasPrefix(link, "http") && !strings.HasPrefix(link, "https") {
+		link = "https://" + link
+	}
+
 	parsedUrl, err := url.Parse(link)
 	if err != nil {
 		return link, err
-	}
-
-	// Check if the scheme is empty, if so default to https
-	// TODO: Avoid parsing the URL twice
-	if parsedUrl.Scheme == "" {
-		link = "https://" + link
-		parsedUrl, err = url.Parse(link)
-		if err != nil {
-			return link, err
-		}
 	}
 
 	if parsedUrl.Scheme != "https" {

--- a/validate/validate_url.go
+++ b/validate/validate_url.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/wavly/shawty/utils"
+	"github.com/wavly/surf/utils"
 )
 
 type InvalidDomainName struct{}

--- a/validate/validate_url.go
+++ b/validate/validate_url.go
@@ -24,7 +24,7 @@ func (*UrlTooLong) Error() string {
 }
 
 func (*DomainTooShort) Error() string {
-	return "Domain is too short, min length is 4 charecters"
+	return "Domain is too short, min length is 4 characters"
 }
 
 func (*InvalidDomainName) Error() string {


### PR DESCRIPTION
This PR simply change the name of the project to 'Surf' (shout out to @resslr for the name).

One notable change is that the `POST` URL `/shawty` which used to shorten the long link and store it in the database is now renamed to `/short` everything else is just renaming.